### PR TITLE
Make the test files deterministic

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -1,9 +1,9 @@
 package binarydist
 
 import (
-	"crypto/rand"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 )
 
@@ -67,8 +67,9 @@ func fileCmp(a, b *os.File) int64 {
 	return -1
 }
 
-func mustWriteRandFile(path string, size int) *os.File {
+func mustWriteRandFile(path string, size int, seed int64) *os.File {
 	p := make([]byte, size)
+	rand.Seed(seed)
 	_, err := rand.Read(p)
 	if err != nil {
 		panic(err)

--- a/diff_test.go
+++ b/diff_test.go
@@ -13,8 +13,8 @@ var diffT = []struct {
 	new *os.File
 }{
 	{
-		old: mustWriteRandFile("test.old", 1e3),
-		new: mustWriteRandFile("test.new", 1e3),
+		old: mustWriteRandFile("test.old", 1e3, 1),
+		new: mustWriteRandFile("test.new", 1e3, 2),
 	},
 	{
 		old: mustOpen("testdata/sample.old"),

--- a/patch_test.go
+++ b/patch_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestPatch(t *testing.T) {
-	mustWriteRandFile("test.old", 1e3)
-	mustWriteRandFile("test.new", 1e3)
+	mustWriteRandFile("test.old", 1e3, 1)
+	mustWriteRandFile("test.new", 1e3, 2)
 
 	got, err := ioutil.TempFile("/tmp", "bspatch.")
 	if err != nil {


### PR DESCRIPTION
This patch was developed in binarydist's Debian package, to support
the [Reproducible Builds](https://reproducible-builds.org/) effort.