### PR TITLE
Fix broken documentation link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,4 +4,4 @@ Package binarydist implements binary diff and patch as described on
 <http://www.daemonology.net/bsdiff/>. It reads and writes files
 compatible with the tools there.
 
-Documentation at <http://go.pkgdoc.org/github.com/kr/binarydist>.
+Documentation at <https://godoc.org/github.com/kr/binarydist>.


### PR DESCRIPTION
Changed [old link](http://go.pkgdoc.org/github.com/kr/binarydist) to [new link](https://godoc.org/github.com/kr/binarydist).